### PR TITLE
fix issue when data available on both sockets simultaneously

### DIFF
--- a/dmrcon.c
+++ b/dmrcon.c
@@ -26,7 +26,6 @@
 #include <string.h> 
 #include <netdb.h>
 #include <ctype.h>
-#include <signal.h>
 #include <time.h>
 #include <sys/types.h> 
 #include <sys/socket.h> 
@@ -1103,7 +1102,7 @@ int main(int argc, char **argv)
 				rxlen = recvfrom(udp1, buf, BUFSIZE, 0, (struct sockaddr *)&rx, &l);
 				udprx = udp1;
 			}
-			if(FD_ISSET(udp2, &udpset)) {
+			else if(FD_ISSET(udp2, &udpset)) {
 				rxlen = recvfrom(udp2, buf, BUFSIZE, 0, (struct sockaddr *)&rx, &l);
 				udprx = udp2;
 			}

--- a/refcon.c
+++ b/refcon.c
@@ -23,7 +23,6 @@
 #include <string.h> 
 #include <netdb.h>
 #include <ctype.h>
-#include <signal.h>
 #include <sys/types.h> 
 #include <sys/socket.h> 
 #include <arpa/inet.h> 
@@ -261,7 +260,7 @@ int main(int argc, char **argv)
 				rxlen = recvfrom(udp1, buf, BUFSIZE, 0, (struct sockaddr *)&rx, &l);
 				udprx = udp1;
 			}
-			if(FD_ISSET(udp2, &udpset)) {
+			else if(FD_ISSET(udp2, &udpset)) {
 				rxlen = recvfrom(udp2, buf, BUFSIZE, 0, (struct sockaddr *)&rx, &l);
 				udprx = udp2;
 			}

--- a/ysfcon.c
+++ b/ysfcon.c
@@ -24,7 +24,6 @@
 #include <string.h> 
 #include <netdb.h>
 #include <ctype.h>
-#include <signal.h>
 #include <sys/types.h> 
 #include <sys/socket.h> 
 #include <arpa/inet.h> 
@@ -1165,7 +1164,7 @@ int main(int argc, char **argv)
 				rxlen = recvfrom(udp1, buf, BUFSIZE, 0, (struct sockaddr *)&rx, &l);
 				udprx = udp1;
 			}
-			if(FD_ISSET(udp2, &udpset)) {
+			else if(FD_ISSET(udp2, &udpset)) {
 				rxlen = recvfrom(udp2, buf, BUFSIZE, 0, (struct sockaddr *)&rx, &l);
 				udprx = udp2;
 			}


### PR DESCRIPTION
This patch fixes an issue with all your connector tools (I did experience it while creating/testing xrfcon) when data gets available on both sockets simultaneously, then data from 1st socket would be discarded and overwritten by data received on the 2nd one. Also removed duplicate include.