### PR TITLE
rewrite callsign on rpt2

### DIFF
--- a/refcon.c
+++ b/refcon.c
@@ -361,6 +361,9 @@ int main(int argc, char **argv)
 				memcpy(&buf[20], ref2, 6);
 				buf[26] = ' ';
 				buf[27] = mod2[0];
+				memcpy(&buf[28], callsign, 6);
+				buf[34] = ' ';
+				buf[35] = 'G';
 				streamid = (buf[14] << 8) | (buf[15] & 0xff);
 				addCCITT161(&buf[17], 41);
 				sendto(udp2, buf, 0x3a, 0, (const struct sockaddr *)&host2, sizeof(host2));
@@ -377,6 +380,9 @@ int main(int argc, char **argv)
 				memcpy(&buf[20], ref2, 6);
 				buf[26] = ' ';
 				buf[27] = mod2[0];
+				memcpy(&buf[28], callsign, 6);
+				buf[34] = ' ';
+				buf[35] = 'G';
 				streamid = (buf[14] << 8) | (buf[15] & 0xff);
 				addCCITT161(&buf[17], 41);
 				sendto(udp2, buf, 0x3a, 0, (const struct sockaddr *)&host2, sizeof(host2));
@@ -393,6 +399,9 @@ int main(int argc, char **argv)
 				memcpy(&buf[20], ref1, 6);
 				buf[26] = ' ';
 				buf[27] = mod1[0];
+				memcpy(&buf[28], callsign, 6);
+				buf[34] = ' ';
+				buf[35] = 'G';
 				streamid = (buf[14] << 8) | (buf[15] & 0xff);
 				addCCITT161(&buf[17], 41);
 				sendto(udp1, buf, 0x3a, 0, (const struct sockaddr *)&host1, sizeof(host1));


### PR DESCRIPTION
Fix issue with XLX transcoded streams refused by dplus reflectors due to invalid rpt2 callsign, XLX sets it as "XLXnnn G" for transcoded streams and dplus ref refuses that callsign.